### PR TITLE
- s3_multipart_finalise flag is introduced and handled in csv & parqu…

### DIFF
--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -121,7 +121,7 @@ public:
 	             const S3AuthParams &auth_params_p, const S3ConfigParams &config_params_p)
 	    : HTTPFileHandle(fs, std::move(path_p), flags, http_params), auth_params(auth_params_p),
 	      config_params(config_params_p), uploads_in_progress(0), parts_uploaded(0), upload_finalized(false),
-	      uploader_has_error(false), upload_exception(nullptr), s3_multipart_finalize(true) {
+	      uploader_has_error(false), upload_exception(nullptr), previously_uploaded_part_count(0) {
 		if (flags.OpenForReading() && flags.OpenForWriting()) {
 			throw NotImplementedException("Cannot open an HTTP file for both reading and writing");
 		} else if (flags.OpenForAppending()) {
@@ -142,6 +142,7 @@ public:
 protected:
 	string multipart_upload_id;
 	size_t part_size;
+	size_t previously_uploaded_part_count;
 
 	//! Write buffers for this file
 	mutex write_buffers_lock;
@@ -160,7 +161,6 @@ protected:
 	//! Info for upload
 	atomic<uint16_t> parts_uploaded;
 	bool upload_finalized = true;
-	bool s3_multipart_finalize;
 
 	//! Error handling in upload threads
 	atomic<bool> uploader_has_error {false};

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -177,7 +177,7 @@ protected:
 		}
 	}
 
-	string GetMultipartUploadId(const string& path);
+	string GetMultipartUploadId(const string &path);
 };
 
 class S3FileSystem : public HTTPFileSystem {
@@ -249,13 +249,13 @@ protected:
 	// helper for ReadQueryParams
 	void GetQueryParam(const string &key, string &param, CPPHTTPLIB_NAMESPACE::Params &query_params);
 
-	string GetFileNameInTempDirectory(const string& s3FileLocation);
+	string GetFileNameInTempDirectory(const string &s3FileLocation);
 
-	pair<bool, string> GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string& s3_file_path);
+	pair<bool, string> GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string &s3_file_path);
 
 	void SaveCurrentStateForS3MultipartFinalize(S3FileHandle &file_handle);
 
-	void RemoveTmpFileIfExist(const string& s3_file_path);
+	void RemoveTmpFileIfExist(const string &s3_file_path);
 };
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

--- a/extension/httpfs/include/s3fs.hpp
+++ b/extension/httpfs/include/s3fs.hpp
@@ -166,6 +166,8 @@ protected:
 	atomic<bool> uploader_has_error {false};
 	std::exception_ptr upload_exception;
 
+	optional_ptr<ClientContext> context;
+
 	void InitializeClient() override;
 
 	//! Rethrow IO Exception originating from an upload thread
@@ -175,7 +177,7 @@ protected:
 		}
 	}
 
-	string getMultipartUploadId(const string& path);
+	string GetMultipartUploadId(const string& path);
 };
 
 class S3FileSystem : public HTTPFileSystem {
@@ -247,11 +249,13 @@ protected:
 	// helper for ReadQueryParams
 	void GetQueryParam(const string &key, string &param, CPPHTTPLIB_NAMESPACE::Params &query_params);
 
-	pair<bool, string> getStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string& s3_file_path);
+	string GetFileNameInTempDirectory(const string& s3FileLocation);
 
-	void saveCurrentStateForS3MultipartFinalize(S3FileHandle &file_handle);
+	pair<bool, string> GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string& s3_file_path);
 
-	void removeTmpFileIfExist(const string& s3_file_path);
+	void SaveCurrentStateForS3MultipartFinalize(S3FileHandle &file_handle);
+
+	void RemoveTmpFileIfExist(const string& s3_file_path);
 };
 
 // Helper class to do s3 ListObjectV2 api call https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -369,35 +369,35 @@ void S3FileHandle::InitializeClient() {
 	http_client = HTTPFileSystem::GetClient(this->http_params, proto_host_port.c_str());
 }
 
-string S3FileSystem::GetFileNameInTempDirectory(const string& s3_fil_location){
-	
+string S3FileSystem::GetFileNameInTempDirectory(const string &s3_fil_location) {
+
 	string file_name = s3_fil_location;
-	if(s3_fil_location.find("s3://") != string::npos){
+	if (s3_fil_location.find("s3://") != string::npos) {
 		file_name = s3_fil_location.substr(5);
 	}
 	file_name = std::regex_replace(file_name, std::regex("/"), "-");
 	size_t dot_pos = file_name.find_last_of(".");
-	if(dot_pos != string::npos){
+	if (dot_pos != string::npos) {
 		file_name = file_name.substr(0, dot_pos);
 	}
 	std::stringstream ss;
-	ss << "/tmp/"<<file_name;
+	ss << "/tmp/" << file_name;
 	return ss.str();
 }
 
-pair<bool, string> S3FileSystem::GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string& path){
+pair<bool, string> S3FileSystem::GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(const string &path) {
 	string file_name = GetFileNameInTempDirectory(path);
 	std::fstream file(file_name);
 	return make_pair(file.good(), file_name);
 }
 
-string S3FileHandle::GetMultipartUploadId(const string& file_name){
+string S3FileHandle::GetMultipartUploadId(const string &file_name) {
 	std::ifstream fin(file_name);
 	string multipartUploadId;
-	fin>>multipartUploadId;
+	fin >> multipartUploadId;
 	idx_t part_no;
 	string etag;
-	while(fin>>part_no>>etag){
+	while (fin >> part_no >> etag) {
 		previously_uploaded_part_count++;
 		part_etags.insert(std::pair<uint16_t, string>(part_no, etag));
 	}
@@ -405,12 +405,11 @@ string S3FileHandle::GetMultipartUploadId(const string& file_name){
 	return multipartUploadId;
 }
 
-
-
 // Opens the multipart upload and returns the ID
 string S3FileSystem::InitializeMultipartUpload(S3FileHandle &file_handle) {
-	pair<bool, string> s3_multipart_finalize_status_data = GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(file_handle.path);
-	if(s3_multipart_finalize_status_data.first == true){
+	pair<bool, string> s3_multipart_finalize_status_data =
+	    GetStatusAndFilenameIfS3MultipartFinalizeIsInProgress(file_handle.path);
+	if (s3_multipart_finalize_status_data.first == true) {
 		return file_handle.GetMultipartUploadId(s3_multipart_finalize_status_data.second);
 	}
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
@@ -450,13 +449,14 @@ void S3FileSystem::NotifyUploadsInProgress(S3FileHandle &file_handle) {
 void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuffer> write_buffer) {
 	auto &s3fs = (S3FileSystem &)file_handle.file_system;
 
-	string query_param = "partNumber=" + to_string(file_handle.previously_uploaded_part_count + write_buffer->part_no + 1) + "&" +
-	                     "uploadId=" + S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
+	string query_param =
+	    "partNumber=" + to_string(file_handle.previously_uploaded_part_count + write_buffer->part_no + 1) + "&" +
+	    "uploadId=" + S3FileSystem::UrlEncode(file_handle.multipart_upload_id, true);
 	unique_ptr<ResponseWrapper> res;
 	case_insensitive_map_t<string>::iterator etag_lookup;
 
 	try {
-		std::cout<<query_param<<std::endl;
+		std::cout << query_param << std::endl;
 		res = s3fs.PutRequest(file_handle, file_handle.path, {}, (char *)write_buffer->Ptr(), write_buffer->idx,
 		                      query_param);
 
@@ -486,7 +486,9 @@ void S3FileSystem::UploadBuffer(S3FileHandle &file_handle, shared_ptr<S3WriteBuf
 	// Insert etag
 	{
 		unique_lock<mutex> lck(file_handle.part_etags_lock);
-		file_handle.part_etags.insert(std::pair<uint16_t, string>(write_buffer->part_no + file_handle.previously_uploaded_part_count, etag_lookup->second.substr(1, etag_lookup->second.length()-2)));
+		file_handle.part_etags.insert(
+		    std::pair<uint16_t, string>(write_buffer->part_no + file_handle.previously_uploaded_part_count,
+		                                etag_lookup->second.substr(1, etag_lookup->second.length() - 2)));
 	}
 
 	file_handle.parts_uploaded++;
@@ -558,29 +560,29 @@ void S3FileSystem::FlushAllBuffers(S3FileHandle &file_handle) {
 	file_handle.RethrowIOError();
 }
 
-void S3FileSystem::SaveCurrentStateForS3MultipartFinalize(S3FileHandle &file_handle){
+void S3FileSystem::SaveCurrentStateForS3MultipartFinalize(S3FileHandle &file_handle) {
 	string file_name = GetFileNameInTempDirectory(file_handle.path);
 	std::ofstream fout(file_name.c_str());
 	std::stringstream ss;
-	ss<<file_handle.multipart_upload_id<<"\n";
-	for(uint16_t i = 0; i < file_handle.parts_uploaded.load() + file_handle.previously_uploaded_part_count; i++){
-		ss<<i<<" "<<file_handle.part_etags.at(i)<<"\n";
+	ss << file_handle.multipart_upload_id << "\n";
+	for (uint16_t i = 0; i < file_handle.parts_uploaded.load() + file_handle.previously_uploaded_part_count; i++) {
+		ss << i << " " << file_handle.part_etags.at(i) << "\n";
 	}
-	fout<<ss.str();
+	fout << ss.str();
 	fout.close();
 }
 
-void S3FileSystem::RemoveTmpFileIfExist(const string& s3_file_path){
-	string tmp_file_name=GetFileNameInTempDirectory(s3_file_path);
+void S3FileSystem::RemoveTmpFileIfExist(const string &s3_file_path) {
+	string tmp_file_name = GetFileNameInTempDirectory(s3_file_path);
 	std::fstream fs(tmp_file_name);
-	if(fs.good()){
+	if (fs.good()) {
 		std::remove(tmp_file_name.c_str());
 	}
 	fs.close();
 }
 
 void S3FileSystem::FinalizeMultipartUpload(S3FileHandle &file_handle) {
-	if(S3MultipartFinaliseSetting::GetSetting(*file_handle.context.get()).GetValue<bool>() == false){
+	if (S3MultipartFinaliseSetting::GetSetting(*file_handle.context.get()).GetValue<bool>() == false) {
 		SaveCurrentStateForS3MultipartFinalize(file_handle);
 		return;
 	}

--- a/extension/httpfs/s3fs.cpp
+++ b/extension/httpfs/s3fs.cpp
@@ -391,12 +391,6 @@ string S3FileHandle::getMultipartUploadId(const string& filename){
 		parts_uploaded++;
 		part_etags.insert(std::pair<uint16_t, string>(part_no, etag));
 	}
-	// the last part in previous stage may not be of part_size. Removing the last one.
-	// In this step, it will be uploaded with part_size of data or be the last part again.
-	if(parts_uploaded > 0){
-		parts_uploaded--;
-		part_etags.erase(parts_uploaded);
-	}
 	fin.close();
 	return multipartUploadId;
 }
@@ -557,7 +551,8 @@ void S3FileSystem::saveCurrentStateForS3MultipartFinalize(S3FileHandle &file_han
 	string fileName = "/tmp/" + file_handle.path.substr(5);
 	std::ofstream fout(fileName);
 	fout<<file_handle.multipart_upload_id<<std::endl;
-	for(uint16_t i = 0; i < file_handle.parts_uploaded.load(); i++){
+	// The last part no and etag will not be stored as that part may not be of part_size size.
+	for(uint16_t i = 0; i < file_handle.parts_uploaded.load() - 1; i++){
 		fout<<i<<" "<<file_handle.part_etags.at(i)<<std::endl;
 	}
 	fout.flush();

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -115,6 +115,9 @@ struct ClientConfig {
 	//! Defaults to PhysicalMaterializedCollector
 	get_result_collector_t result_collector = nullptr;
 
+	//! S3 upload will be finalised by default
+	bool s3_multipart_upload = true;
+
 public:
 	static ClientConfig &GetConfig(ClientContext &context);
 	static const ClientConfig &GetConfig(const ClientContext &context);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -607,10 +607,10 @@ struct SearchPathSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
-
 struct S3MultipartFinaliseSetting {
 	static constexpr const char *Name = "s3_multipart_finalise";
-	static constexpr const char *Description = "Flag to indicate whether to finalise the s3 upload or wait for more upload";
+	static constexpr const char *Description =
+	    "Flag to indicate whether to finalise the s3 upload or wait for more upload";
 	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
 	static void SetLocal(ClientContext &context, const Value &parameter);
 	static void ResetLocal(ClientContext &context);

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -607,6 +607,16 @@ struct SearchPathSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+
+struct S3MultipartFinaliseSetting {
+	static constexpr const char *Name = "s3_multipart_finalise";
+	static constexpr const char *Description = "Flag to indicate whether to finalise the s3 upload or wait for more upload";
+	static constexpr const LogicalTypeId InputType = LogicalTypeId::BOOLEAN;
+	static void SetLocal(ClientContext &context, const Value &parameter);
+	static void ResetLocal(ClientContext &context);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct SecretDirectorySetting {
 	static constexpr const char *Name = "secret_directory";
 	static constexpr const char *Description = "Set the directory to which persistent secrets are stored";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -114,6 +114,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(ProgressBarTimeSetting),
     DUCKDB_LOCAL(SchemaSetting),
     DUCKDB_LOCAL(SearchPathSetting),
+	DUCKDB_LOCAL(S3MultipartFinaliseSetting),
     DUCKDB_GLOBAL(SecretDirectorySetting),
     DUCKDB_GLOBAL(DefaultSecretStorage),
     DUCKDB_GLOBAL(TempDirectorySetting),

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -114,7 +114,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(ProgressBarTimeSetting),
     DUCKDB_LOCAL(SchemaSetting),
     DUCKDB_LOCAL(SearchPathSetting),
-	DUCKDB_LOCAL(S3MultipartFinaliseSetting),
+    DUCKDB_LOCAL(S3MultipartFinaliseSetting),
     DUCKDB_GLOBAL(SecretDirectorySetting),
     DUCKDB_GLOBAL(DefaultSecretStorage),
     DUCKDB_GLOBAL(TempDirectorySetting),

--- a/src/main/settings/settings.cpp
+++ b/src/main/settings/settings.cpp
@@ -806,6 +806,21 @@ Value FileSearchPathSetting::GetSetting(const ClientContext &context) {
 }
 
 //===--------------------------------------------------------------------===//
+// S3 Multipart Finalise
+//===--------------------------------------------------------------------===//
+void S3MultipartFinaliseSetting::ResetLocal(ClientContext &context) {
+	ClientConfig::GetConfig(context).s3_multipart_upload = ClientConfig().s3_multipart_upload;
+}
+
+void S3MultipartFinaliseSetting::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).s3_multipart_upload = input.GetValue<bool>();
+}
+
+Value S3MultipartFinaliseSetting::GetSetting(const ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).s3_multipart_upload);
+}
+
+//===--------------------------------------------------------------------===//
 // Force Compression
 //===--------------------------------------------------------------------===//
 void ForceCompressionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -108,7 +108,8 @@ OptionValueSet &GetValueForOption(const string &name) {
 	    {"enable_http_metadata_cache", {true}},
 	    {"force_bitpacking_mode", {"constant"}},
 	    {"allocator_flush_threshold", {"4.0 GiB"}},
-	    {"arrow_large_buffer_size", {true}}};
+	    {"arrow_large_buffer_size", {true}},
+	    {"s3_multipart_finalise", {false}}};
 	// Every option that's not excluded has to be part of this map
 	if (!value_map.count(name)) {
 		REQUIRE(name == "MISSING_FROM_MAP");


### PR DESCRIPTION
…et parser

- When s3_multipart_finalise is false, current multipart id and part no along with etags are stored in /tmp/ directory
- When corresponding file is found in /tmp/ directory, it reconstructs the state of previous copy operation with s3_finalize_finalise as false